### PR TITLE
Removed subclass-specific propery getters and setters

### DIFF
--- a/org.eclipse.eavp.viz.service.paraview/src/org/eclipse/eavp/viz/service/paraview/ParaViewPlot.java
+++ b/org.eclipse.eavp.viz.service.paraview/src/org/eclipse/eavp/viz/service/paraview/ParaViewPlot.java
@@ -31,8 +31,10 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.eavp.viz.service.AbstractSeries;
@@ -54,6 +56,8 @@ import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.browser.IWebBrowser;
 import org.eclipse.ui.part.MultiPageEditorPart;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -517,8 +521,15 @@ public class ParaViewPlot extends ConnectionPlot<IParaViewWebClient> {
 	public ArrayList<Action> getCustomActions() {
 
 		// Get the plus icon image
-		URL inImageURL = getClass().getResource(
-				"/icons" + System.getProperty("file.separator") + "add.png");
+
+		String separator = System.getProperty("file.separator");
+		URL inImageURL = getClass().getResource(separator +
+				"icons" + separator + "add.png");
+		if(inImageURL == null){
+			Bundle bundle = FrameworkUtil.getBundle(getClass());
+			Path inImagePath = new Path("/icons" + System.getProperty("file.separator") + "add.png");
+			inImageURL = FileLocator.find(bundle, inImagePath, null);
+		}
 		ImageDescriptor inDescriptor = ImageDescriptor
 				.createFromURL(inImageURL);
 
@@ -551,9 +562,14 @@ public class ParaViewPlot extends ConnectionPlot<IParaViewWebClient> {
 			}
 		};
 
-		// Get the plus icon image
-		URL outImageURL = getClass().getResource("/icons"
-				+ System.getProperty("file.separator") + "complement.gif");
+		// Get the minus icon image
+		URL outImageURL = getClass().getResource(separator + "icons"
+				+ separator + "complement.gif");
+		if(outImageURL == null){
+			Bundle bundle = FrameworkUtil.getBundle(getClass());
+			Path outImagePath = new Path("/icons" + System.getProperty("file.separator") + "complement.gif");
+			outImageURL = FileLocator.find(bundle, outImagePath, null);
+		}
 		ImageDescriptor outDescriptor = ImageDescriptor
 				.createFromURL(outImageURL);
 
@@ -586,9 +602,14 @@ public class ParaViewPlot extends ConnectionPlot<IParaViewWebClient> {
 			}
 		};
 
-		// Get the plus icon image
-		URL resetImageURL = getClass().getResource("/icons"
-				+ System.getProperty("file.separator") + "iu_update_obj.gif");
+		// Get the reset icon image
+		URL resetImageURL = getClass().getResource(separator + "icons"
+				+ separator + "iu_update_obj.gif");
+		if(resetImageURL == null){
+			Bundle bundle = FrameworkUtil.getBundle(getClass());
+			Path resetImagePath = new Path("/icons" + System.getProperty("file.separator") + "iu_update_obj.gif");
+			resetImageURL = FileLocator.find(bundle, resetImagePath, null);
+		}
 		ImageDescriptor resetDescriptor = ImageDescriptor
 				.createFromURL(resetImageURL);
 

--- a/org.eclipse.eavp.viz.service.visit/src/org/eclipse/eavp/viz/service/visit/VisItPlot.java
+++ b/org.eclipse.eavp.viz.service.visit/src/org/eclipse/eavp/viz/service/visit/VisItPlot.java
@@ -22,8 +22,10 @@ import java.util.Map;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
+import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.eavp.viz.service.AbstractSeries;
@@ -36,6 +38,8 @@ import org.eclipse.jface.action.Action;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 import gov.lbnl.visit.swt.VisItSwtConnection;
 import visit.java.client.FileInfo;
@@ -301,8 +305,14 @@ public class VisItPlot extends ConnectionPlot<VisItSwtConnection> {
 		ArrayList<Action> actions = new ArrayList<Action>();
 
 		// Get the plus icon image
-		URL inImageURL = getClass().getResource(
-				"/icons" + System.getProperty("file.separator") + "add.png");
+		String separator = System.getProperty("file.separator");
+		URL inImageURL = getClass().getResource(separator + 
+				"icons" + separator + "add.png");
+		if(inImageURL == null){
+			Bundle bundle = FrameworkUtil.getBundle(getClass());
+			Path inImagePath = new Path("/icons" + System.getProperty("file.separator") + "add.png");
+			inImageURL = FileLocator.find(bundle, inImagePath, null);
+		}
 		ImageDescriptor inDescriptor = ImageDescriptor
 				.createFromURL(inImageURL);
 
@@ -320,8 +330,13 @@ public class VisItPlot extends ConnectionPlot<VisItSwtConnection> {
 		actions.add(zoomIn);
 
 		// Get the minus icon image
-		URL outImageURL = getClass().getResource("/icons"
-				+ System.getProperty("file.separator") + "complement.gif");
+		URL outImageURL = getClass().getResource(separator + "icons"
+				+ separator + "complement.gif");
+		if(outImageURL == null){
+			Bundle bundle = FrameworkUtil.getBundle(getClass());
+			Path outImagePath = new Path("/icons" + System.getProperty("file.separator") + "complement.gif");
+			outImageURL = FileLocator.find(bundle, outImagePath, null);
+		}
 		ImageDescriptor outDescriptor = ImageDescriptor
 				.createFromURL(outImageURL);
 
@@ -339,8 +354,13 @@ public class VisItPlot extends ConnectionPlot<VisItSwtConnection> {
 		actions.add(zoomOut);
 
 		// Get the refresh icon image
-		URL resetImageURL = getClass().getResource("/icons"
-				+ System.getProperty("file.separator") + "iu_update_obj.gif");
+		URL resetImageURL = getClass().getResource(separator + "icons"
+				+ separator + "iu_update_obj.gif");
+		if(resetImageURL == null){
+			Bundle bundle = FrameworkUtil.getBundle(getClass());
+			Path resetImagePath = new Path("/icons" + System.getProperty("file.separator") + "iu_update_obj.gif");
+			resetImageURL = FileLocator.find(bundle, resetImagePath, null);
+		}
 		ImageDescriptor resetDescriptor = ImageDescriptor
 				.createFromURL(resetImageURL);
 

--- a/org.eclipse.january.geometry.model/model/geometry.ecore
+++ b/org.eclipse.january.geometry.model/model/geometry.ecore
@@ -98,6 +98,8 @@
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="radius" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EDouble">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="suppressedGetVisibility" value="true"/>
+        <details key="suppressedSetVisibility" value="true"/>
         <details key="documentation" value="The radius is the distance from the center of the sphere to any point on the surface. It is constant across the entire sphere."/>
       </eAnnotations>
     </eStructuralFeatures>
@@ -109,6 +111,8 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="sideLength" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EDouble">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="documentation" value="The length of any side of the box."/>
+        <details key="suppressedGetVisibility" value="true"/>
+        <details key="suppressedSetVisibility" value="true"/>
       </eAnnotations>
     </eStructuralFeatures>
   </eClassifiers>
@@ -119,11 +123,15 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="radius" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EDouble">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="documentation" value="The radius is the shortest distance from a point on the surface of the cylinder to the central axis. It is constant across the entire cylinder."/>
+        <details key="supressedGetVisibility" value="true"/>
+        <details key="supressedSetVisibility" value="true"/>
       </eAnnotations>
     </eStructuralFeatures>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="height" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EDouble">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="documentation" value="The length of the central axis of the cylinder."/>
+        <details key="suppressedGetVisibility" value="true"/>
+        <details key="supressedSetVisibility" value="true"/>
       </eAnnotations>
     </eStructuralFeatures>
   </eClassifiers>
@@ -142,18 +150,24 @@
         defaultValueLiteral="0.0">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="documentation" value="The cylinder's height."/>
+        <details key="suppressedGetVisibility" value="true"/>
+        <details key="suppressedSetVisibility" value="true"/>
       </eAnnotations>
     </eStructuralFeatures>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="innerRadius" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EDouble"
         defaultValueLiteral="0.0">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="documentation" value="The radius of the inner hole bored through the outer cylinder to form the pipe. This value must be no greater than radius. "/>
+        <details key="suppressedGetVisibility" value="true"/>
+        <details key="suppressedSetVisibility" value="true"/>
       </eAnnotations>
     </eStructuralFeatures>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="radius" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EDouble"
         defaultValueLiteral="0.0">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="documentation" value="The radius of the circle forming the outer edge of the tube."/>
+        <details key="suppressedGetVisibility" value="true"/>
+        <details key="suppressedSetVisibility" value="true"/>
       </eAnnotations>
     </eStructuralFeatures>
   </eClassifiers>


### PR DESCRIPTION
Removed the getters and setters for attributes like a sphere's radius,
so that all changes to a shape's properties must be sent through the
setProperty() function.

Signed-off-by: Robert Smith SmithRW@ornl.gov
